### PR TITLE
Added optional node names to the svg

### DIFF
--- a/fdg-img/examples/img_social_network.rs
+++ b/fdg-img/examples/img_social_network.rs
@@ -1,11 +1,32 @@
 use std::fs;
 
+use fdg_img::Settings;
 use fdg_sim::{force, json};
+use plotters::style::{*, text_anchor::*, BLACK};
 
 fn main() {
     let graph = json::graph_from_json(include_str!("../../datasets/social_network.json")).unwrap();
 
-    let svg = fdg_img::gen_image(&graph, &force::handy(45.0, 0.975, true, true), None).unwrap();
+    let text_style = Some(TextStyle {
+        font: ("sans-serif", 20).into_font(),
+        color: BLACK.to_backend_color()  ,
+        pos: Pos {
+            h_pos: HPos::Left,
+            v_pos: VPos::Center,
+        },
+    });
+
+    let svg = fdg_img::gen_image(
+        &graph,
+        &force::handy(45.0, 0.975, true, true),
+        Some(Settings {
+            text_style,
+            node_color: (100, 100, 100),
+            edge_color: (150,150,150),
+            ..Default::default()
+        }),
+    )
+    .unwrap();
 
     fs::write("social_network.svg", svg.as_bytes()).unwrap();
 }

--- a/fdg-img/examples/img_social_network.rs
+++ b/fdg-img/examples/img_social_network.rs
@@ -2,14 +2,14 @@ use std::fs;
 
 use fdg_img::Settings;
 use fdg_sim::{force, json};
-use plotters::style::{*, text_anchor::*, BLACK};
+use plotters::style::{text_anchor::*, BLACK, *};
 
 fn main() {
     let graph = json::graph_from_json(include_str!("../../datasets/social_network.json")).unwrap();
 
     let text_style = Some(TextStyle {
         font: ("sans-serif", 20).into_font(),
-        color: BLACK.to_backend_color()  ,
+        color: BLACK.to_backend_color(),
         pos: Pos {
             h_pos: HPos::Left,
             v_pos: VPos::Center,
@@ -22,7 +22,7 @@ fn main() {
         Some(Settings {
             text_style,
             node_color: (100, 100, 100),
-            edge_color: (150,150,150),
+            edge_color: (150, 150, 150),
             ..Default::default()
         }),
     )

--- a/fdg-img/src/lib.rs
+++ b/fdg-img/src/lib.rs
@@ -71,8 +71,16 @@ pub fn gen_image<N: Clone, E: Clone>(
         for node in sim.get_graph().node_weights() {
             let loc = node.location;
 
-            let rightmost = match settings.text_style.clone() { //Make sure that the text isn't cut off
-                Some(ts) => loc.x + ts.font.box_size(&node.name).ok().map(|x|x.0 as f32).unwrap_or(0.0) ,
+            let rightmost = match settings.text_style.clone() {
+                //Make sure that the text isn't cut off
+                Some(ts) => {
+                    loc.x
+                        + ts.font
+                            .box_size(&node.name)
+                            .ok()
+                            .map(|x| x.0 as f32)
+                            .unwrap_or(0.0)
+                }
                 None => loc.x,
             };
 
@@ -173,7 +181,10 @@ pub fn gen_image<N: Clone, E: Clone>(
 
     if let Some(text_style) = settings.text_style {
         for node in sim.get_graph().node_weights() {
-            let pos = (node.location.x as i32 + (text_style.font.get_size() / 2.) as i32, node.location.y as i32);
+            let pos = (
+                node.location.x as i32 + (text_style.font.get_size() / 2.) as i32,
+                node.location.y as i32,
+            );
             backend.draw_text(node.name.as_str(), &text_style, pos)?;
         }
     }

--- a/fdg-img/src/lib.rs
+++ b/fdg-img/src/lib.rs
@@ -20,6 +20,8 @@ pub struct Settings {
     pub edge_color: (u8, u8, u8),
     pub background_color: (u8, u8, u8),
     pub print_progress: bool,
+    ///If supplied, the names of nodes will be written
+    pub text_style: Option<TextStyle<'static>>,
 }
 
 impl Default for Settings {
@@ -33,6 +35,7 @@ impl Default for Settings {
             edge_color: (255, 0, 0),
             background_color: (255, 255, 255),
             print_progress: true,
+            text_style: None,
         }
     }
 }
@@ -68,8 +71,13 @@ pub fn gen_image<N: Clone, E: Clone>(
         for node in sim.get_graph().node_weights() {
             let loc = node.location;
 
-            if loc.x > right {
-                right = loc.x;
+            let rightmost = match settings.text_style.clone() { //Make sure that the text isn't cut off
+                Some(ts) => loc.x + ts.font.box_size(&node.name).ok().map(|x|x.0 as f32).unwrap_or(0.0) ,
+                None => loc.x,
+            };
+
+            if rightmost > right {
+                right = rightmost;
             }
 
             if loc.x < left {
@@ -161,6 +169,13 @@ pub fn gen_image<N: Clone, E: Clone>(
                 stroke_width: 1,
             },
         ))?;
+    }
+
+    if let Some(text_style) = settings.text_style {
+        for node in sim.get_graph().node_weights() {
+            let pos = (node.location.x as i32 + (text_style.font.get_size() / 2.) as i32, node.location.y as i32);
+            backend.draw_text(node.name.as_str(), &text_style, pos)?;
+        }
     }
 
     drop(backend);


### PR DESCRIPTION
Closes https://github.com/grantshandy/fdg/issues/3

I added a TextStyle parameter to the Settings. If set, node names are drawn on the graph. I did a little bit to make the names not overlap the circles and not get cut off by the graph edges but things can still be a bit messy in crowded graphs.

This is technically a breaking change but no tests or examples were broken.  I added node names to the social network example.