### PR TITLE
fix division by zero

### DIFF
--- a/fdg-sim/src/force/mod.rs
+++ b/fdg-sim/src/force/mod.rs
@@ -200,5 +200,5 @@ pub fn translate<N, E, Ty: EdgeType>() -> Force<N, E, Ty> {
 
 #[doc(hidden)]
 pub fn unit_vector(a: Vec3, b: Vec3) -> Vec3 {
-    (b - a) / a.distance(b)
+    (b - a).normalize_or_zero()
 }


### PR DESCRIPTION
Hi,

unit_vector(a,b) sometimes divides by zero (a==b).
With the consequence of creating a blank output with fdg-img.

Have a good day