### PR TITLE
Fix ImageSettings fallback condition

### DIFF
--- a/fdg-img/src/wasm.rs
+++ b/fdg-img/src/wasm.rs
@@ -125,7 +125,7 @@ pub struct Color {
 
 #[wasm_bindgen]
 pub fn generate_svg(jsongraph: JsValue, settings: JsValue) -> Result<String, JsError> {
-    let settings: ImageSettings = if settings != JsValue::NULL || settings != JsValue::UNDEFINED {
+    let settings: ImageSettings = if settings != JsValue::NULL && settings != JsValue::UNDEFINED {
         match settings.into_serde() {
             Ok(settings) => settings,
             Err(err) => return Err(JsError::new(&format!("settings has invalid format: {err}"))),


### PR DESCRIPTION
I believe this condition is incorrect, we want to try de-serialize settings if it's not NULL and it's not UNDEFINED.

Else, if I pass NULL to the function it still throws an error, when I was expecting the default settings.