### PR TITLE
Improve fdg-wasm

### DIFF
--- a/fdg-img/Cargo.toml
+++ b/fdg-img/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
 serde_json = { version = "1.0", optional = true }
+serde-wasm-bindgen = "0.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
 plotters = "0.3"
 fdg-sim = "0.8"

--- a/fdg-img/examples/cylinder_img.rs
+++ b/fdg-img/examples/cylinder_img.rs
@@ -1,3 +1,5 @@
+#![allow(unused_parens)]
+
 use std::fs;
 
 use fdg_sim::{petgraph::graph::NodeIndex, ForceGraph, ForceGraphHelper};

--- a/fdg-img/examples/sphere_img.rs
+++ b/fdg-img/examples/sphere_img.rs
@@ -1,3 +1,5 @@
+#![allow(unused_parens)]
+
 use std::fs;
 
 use fdg_sim::{petgraph::graph::NodeIndex, ForceGraph, ForceGraphHelper};

--- a/fdg-img/src/wasm.rs
+++ b/fdg-img/src/wasm.rs
@@ -126,7 +126,7 @@ pub struct Color {
 #[wasm_bindgen]
 pub fn generate_svg(jsongraph: JsValue, settings: JsValue) -> Result<String, JsError> {
     let settings: ImageSettings = if settings != JsValue::NULL && settings != JsValue::UNDEFINED {
-        match settings.into_serde() {
+        match serde_wasm_bindgen::from_value(settings) {
             Ok(settings) => settings,
             Err(err) => return Err(JsError::new(&format!("settings has invalid format: {err}"))),
         }
@@ -134,7 +134,7 @@ pub fn generate_svg(jsongraph: JsValue, settings: JsValue) -> Result<String, JsE
         ImageSettings::default()
     };
 
-    let jsongraph: Value = match jsongraph.into_serde() {
+    let jsongraph: Value = match serde_wasm_bindgen::from_value(jsongraph) {
         Ok(jsongraph) => jsongraph,
         Err(err) => return Err(JsError::new(&err.to_string())),
     };

--- a/fdg-macroquad/examples/view_cylinder.rs
+++ b/fdg-macroquad/examples/view_cylinder.rs
@@ -1,3 +1,5 @@
+#![allow(unused_parens)]
+
 use fdg_sim::{petgraph::graph::NodeIndex, ForceGraph, ForceGraphHelper};
 
 #[macroquad::main("Force Graph Cylinder Demo")]

--- a/fdg-macroquad/examples/view_sphere.rs
+++ b/fdg-macroquad/examples/view_sphere.rs
@@ -1,3 +1,5 @@
+#![allow(unused_parens)]
+
 use fdg_sim::{petgraph::graph::NodeIndex, ForceGraph, ForceGraphHelper};
 
 #[macroquad::main("Force Graph Sphere Demo")]

--- a/fdg-wasm/src/lib.rs
+++ b/fdg-wasm/src/lib.rs
@@ -203,6 +203,7 @@ impl ForceGraphSimulator {
         self.sim.reset_node_placement();
     }
 
+    /// Set the simulator to use 2 or 3 dimensions.
     #[wasm_bindgen(js_name = "setDimensions")]
     pub fn set_dimensions(&mut self, dimensions: u8) {
         let dimensions = match dimensions {

--- a/fdg-wasm/src/lib.rs
+++ b/fdg-wasm/src/lib.rs
@@ -57,10 +57,7 @@ impl ForceGraphSimulator {
 
     #[wasm_bindgen(setter, js_name = "graph")]
     pub fn set_graph(&mut self, json: JsValue) -> Result<(), JsError> {
-        let inner_graph: Value = match serde_wasm_bindgen::from_value(json) {
-            Ok(json) => json,
-            Err(err) => return Err(JsError::new(err.to_string().as_str())),
-        };
+        let inner_graph: Value = serde_wasm_bindgen::from_value(json)?;
 
         if !inner_graph.is_object() {
             return Err(JsError::new("graph must be an object"));
@@ -86,10 +83,7 @@ impl ForceGraphSimulator {
     pub fn get_graph(&mut self) -> Result<JsValue, JsError> {
         let new_graph = wasm_to_serde_graph(self.sim.get_graph())?;
 
-        let serde_graph = match json::graph_to_json(&new_graph) {
-            Ok(json) => json,
-            Err(err) => return Err(JsError::new(err.to_string().as_str())),
-        };
+        let serde_graph = json::graph_to_json(&new_graph)?;
 
         let inner_serde_graph = match serde_graph.get("graph") {
             Some(graph) => graph,

--- a/fdg-wasm/src/lib.rs
+++ b/fdg-wasm/src/lib.rs
@@ -266,7 +266,7 @@ fn serde_to_wasm_graph(
     let mut new_graph: ForceGraph<JsValue, JsValue> = ForceGraph::default();
 
     for node in graph.node_weights() {
-        let weight = JsValue::from_serde(&node.data)?;
+        let weight = serde_wasm_bindgen::to_value(&node.data)?;
         new_graph.add_force_node(node.name.clone(), weight);
     }
 
@@ -274,7 +274,7 @@ fn serde_to_wasm_graph(
         new_graph.add_edge(
             edge.source(),
             edge.target(),
-            JsValue::from_serde(&edge.weight())?,
+            serde_wasm_bindgen::to_value(&edge.weight())?,
         );
     }
 
@@ -287,12 +287,12 @@ fn wasm_to_serde_graph(
     let mut new_graph: ForceGraph<Value, Value> = ForceGraph::default();
 
     for node in graph.node_weights() {
-        let weight: Value = node.data.into_serde()?;
+        let weight: Value = serde_wasm_bindgen::from_value(node.data.clone())?;
         new_graph.add_force_node(node.name.clone(), weight);
     }
 
     for edge in graph.edge_references() {
-        let weight: Value = edge.weight().into_serde()?;
+        let weight: Value = serde_wasm_bindgen::from_value(edge.weight().clone())?;
         new_graph.add_edge(edge.source(), edge.target(), weight);
     }
 

--- a/fdg-wasm/src/lib.rs
+++ b/fdg-wasm/src/lib.rs
@@ -55,7 +55,7 @@ impl ForceGraphSimulator {
         Self { sim }
     }
 
-    #[wasm_bindgen(method, setter, js_name = "graph")]
+    #[wasm_bindgen(setter, js_name = "graph")]
     pub fn set_graph(&mut self, json: JsValue) -> Result<(), JsError> {
         let inner_graph: Value = match serde_wasm_bindgen::from_value(json) {
             Ok(json) => json,
@@ -82,7 +82,7 @@ impl ForceGraphSimulator {
         Ok(())
     }
 
-    #[wasm_bindgen(method, getter, js_name = "graph")]
+    #[wasm_bindgen(getter, js_name = "graph")]
     pub fn get_graph(&mut self) -> Result<JsValue, JsError> {
         let new_graph = wasm_to_serde_graph(self.sim.get_graph())?;
 
@@ -119,7 +119,7 @@ impl ForceGraphSimulator {
         }
     }
 
-    #[wasm_bindgen(method, getter, js_name = "nodes")]
+    #[wasm_bindgen(getter, js_name = "nodes")]
     pub fn get_nodes(&self) -> Array {
         let array = Array::new();
 
@@ -174,7 +174,7 @@ impl ForceGraphSimulator {
         Ok(())
     }
 
-    #[wasm_bindgen(method, getter, js_name = "edges")]
+    #[wasm_bindgen(getter, js_name = "edges")]
     pub fn get_edges(&self) -> Array {
         let array = Array::new();
         let graph = self.sim.get_graph();

--- a/fdg-wasm/src/lib.rs
+++ b/fdg-wasm/src/lib.rs
@@ -125,6 +125,27 @@ impl ForceGraphSimulator {
         }
     }
 
+    #[wasm_bindgen(js_name = "addNodeWithCoords")]
+    pub fn add_node_with_coords(
+        &mut self,
+        name: String,
+        weight: JsValue,
+        x: f32,
+        y: f32,
+        z: f32,
+    ) -> Result<usize, JsError> {
+        match node_index_from_name(self.sim.get_graph(), &name) {
+            Some(_) => Err(JsError::new(&format!(
+                "node with name \"{name}\" already in graph"
+            ))),
+            None => Ok(self
+                .sim
+                .get_graph_mut()
+                .add_force_node_with_coords(name, weight, Vec3::new(x, y, z))
+                .index()),
+        }
+    }
+
     #[wasm_bindgen(getter, js_name = "nodes")]
     pub fn get_nodes(&self) -> GraphNodes {
         let array = Array::new();

--- a/fdg-wasm/src/lib.rs
+++ b/fdg-wasm/src/lib.rs
@@ -39,6 +39,18 @@ pub fn jsongraph_to_dot(json: String) -> Result<JsValue, JsError> {
 }
 
 #[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "ForceGraphNode[]")]
+    pub type GraphNodes;
+
+    #[wasm_bindgen(typescript_type = "ForceGraphEdge[]")]
+    pub type GraphEdges;
+
+    #[wasm_bindgen(typescript_type = "string | number")]
+    pub type NodeReference;
+}
+
+#[wasm_bindgen]
 pub struct ForceGraphSimulator {
     sim: Simulation<JsValue, JsValue>,
 }
@@ -114,7 +126,7 @@ impl ForceGraphSimulator {
     }
 
     #[wasm_bindgen(getter, js_name = "nodes")]
-    pub fn get_nodes(&self) -> Array {
+    pub fn get_nodes(&self) -> GraphNodes {
         let array = Array::new();
 
         for node in self.sim.get_graph().node_weights() {
@@ -123,14 +135,14 @@ impl ForceGraphSimulator {
             array.push(&node.into());
         }
 
-        array
+        JsValue::from(array).into()
     }
 
     #[wasm_bindgen(js_name = "addEdge")]
     pub fn add_edge(
         &mut self,
-        source: JsValue,
-        target: JsValue,
+        source: NodeReference,
+        target: NodeReference,
         weight: JsValue,
     ) -> Result<(), JsError> {
         let source: NodeIndex = if let Some(source) = source.as_string() {
@@ -169,7 +181,7 @@ impl ForceGraphSimulator {
     }
 
     #[wasm_bindgen(getter, js_name = "edges")]
-    pub fn get_edges(&self) -> Array {
+    pub fn get_edges(&self) -> GraphEdges {
         let array = Array::new();
         let graph = self.sim.get_graph();
 
@@ -183,7 +195,7 @@ impl ForceGraphSimulator {
             array.push(&edge.into());
         }
 
-        array
+        JsValue::from(array).into()
     }
 
     #[wasm_bindgen(js_name = "resetNodePlacement")]
@@ -216,7 +228,7 @@ impl ForceGraphSimulator {
     }
 
     #[wasm_bindgen(js_name = "nodeInfo")]
-    pub fn node_info(&self, name: JsValue) -> JsValue {
+    pub fn node_info(&self, name: NodeReference) -> JsValue {
         let idx: NodeIndex = if let Some(name) = name.as_string() {
             match node_index_from_name(self.sim.get_graph(), &name) {
                 Some(idx) => idx,

--- a/fdg-wasm/src/subtypes/edge.rs
+++ b/fdg-wasm/src/subtypes/edge.rs
@@ -11,17 +11,17 @@ pub struct ForceGraphEdge {
 
 #[wasm_bindgen]
 impl ForceGraphEdge {
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn source(&self) -> ForceGraphNode {
         self.source.to_owned()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn target(&self) -> ForceGraphNode {
         self.target.to_owned()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn metadata(&self) -> JsValue {
         self.metadata.to_owned()
     }

--- a/fdg-wasm/src/subtypes/node.rs
+++ b/fdg-wasm/src/subtypes/node.rs
@@ -49,22 +49,22 @@ impl ForceGraphNode {
 
 #[wasm_bindgen]
 impl ForceGraphNode {
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn name(&self) -> String {
         self.name.to_owned()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn label(&self) -> JsValue {
         self.label.to_owned()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn location(&self) -> Vec<Number> {
         self.location.iter().map(|x| Number::from(*x)).collect()
     }
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(getter)]
     pub fn metadata(&self) -> JsValue {
         self.metadata.to_owned()
     }

--- a/fdg-wasm/src/subtypes/node.rs
+++ b/fdg-wasm/src/subtypes/node.rs
@@ -17,13 +17,13 @@ impl ForceGraphNode {
         let name = node.name.to_owned();
         let location = vec![node.location.x, node.location.y, node.location.z];
 
-        let data: Value = match node.data.to_owned().into_serde() {
+        let data: Value = match serde_wasm_bindgen::from_value(node.data.to_owned()) {
             Ok(data) => data,
             Err(_) => Value::Null,
         };
 
         let label = match data.get("label") {
-            Some(label) => match JsValue::from_serde(label) {
+            Some(label) => match serde_wasm_bindgen::to_value(label) {
                 Ok(label) => label,
                 Err(_) => JsValue::NULL,
             },
@@ -31,7 +31,7 @@ impl ForceGraphNode {
         };
 
         let metadata = match data.get("metadata") {
-            Some(metadata) => match JsValue::from_serde(metadata) {
+            Some(metadata) => match serde_wasm_bindgen::to_value(metadata) {
                 Ok(metadata) => metadata,
                 Err(_) => JsValue::NULL,
             },


### PR DESCRIPTION
This has a few commits stacked that could be unbundled. The final change here is the introduction of `ForceGraphSimulator.addNodeWithCoords`, which enables passing initial positions for nodes when adding them to the simulator.